### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ class AnimatorViewController: CycleAnimatorViewController {
 }
 ```
 
-##Screenshot
+## Screenshot
 
 ```
 常规图片轮播器


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
